### PR TITLE
Fix Python 3.9 incompatibility in latency monitor

### DIFF
--- a/monitor_latency.py
+++ b/monitor_latency.py
@@ -3,6 +3,7 @@
 
 import os, re, time, sys, subprocess, socket, datetime, json
 import urllib.request, urllib.parse, urllib.error
+from typing import Optional
 import oci
 
 def log(msg): print(msg, flush=True)
@@ -30,7 +31,7 @@ def tcp_ping(ip, port=22, timeout=2):
         return False
 
 # ICMP 平均延迟
-def measure_latency(ip: str, count: int = 5, timeout_s: int = 2) -> float | None:
+def measure_latency(ip: str, count: int = 5, timeout_s: int = 2) -> Optional[float]:
     try:
         # -n 纯数字；-W 超时秒；-c 次数
         cmd = ["ping", "-n", "-W", str(timeout_s), "-c", str(count), ip]


### PR DESCRIPTION
## Summary
- replace union type hint with `Optional[float]` for compatibility with Python 3.9 and earlier
- import `Optional` from `typing`

## Testing
- `python3 -m py_compile monitor_latency.py`
- `python3 monitor_latency.py` *(fails: ModuleNotFoundError: No module named 'oci'; pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e6eab06083269de17fc47fa3f7da